### PR TITLE
Fix Issue #7 

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -11,3 +11,8 @@
     width:100%;
     position:absolute;
 }
+/* Fixes bug specific to Microsoft Edge, where parallax background image jumps up and down
+   Image is part of Hugo's Strata theme */
+_:-ms-lang(x), #header { 
+    background-attachment:scroll;
+}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -11,3 +11,8 @@
     width:100%;
     position:absolute;
 }
+/* Fixes bug specific to Microsoft Edge, where parallax background image jumps up and down
+   Image is part of Hugo's Strata theme */
+_:-ms-lang(x), #header { 
+    background-attachment:scroll;
+}


### PR DESCRIPTION
Prevent parallax background img from being jumpy when Microsoft Edge
users scroll through site. See Issue #7
A CSS rule in main.css was causing the problem. It set the
background-attachment property of #header to both "scroll" and "fixed."